### PR TITLE
Begin work on send endpoint.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Improvements:
         create_join_event_template::v1
     },
     query::get_room_information::v1,
+    transactions::send_transaction_message::v1,
     version::get_server_version::v1
   ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,9 +16,10 @@ pub mod directory;
 pub mod discovery;
 pub mod membership;
 pub mod query;
+pub mod transactions;
 
 /// A 'persistent data unit' (event) for room versions 3 and beyond.
-#[derive(Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RoomV3Pdu {
     /// The room this event belongs to.
     pub room_id: RoomId,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,70 +2,11 @@
 
 #![warn(missing_docs)]
 
-use std::{collections::BTreeMap, time::SystemTime};
-
-use ::serde::{Deserialize, Serialize};
-use js_int::UInt;
-use ruma_events::EventType;
-use ruma_identifiers::{EventId, RoomId, UserId};
-use serde_json::Value as JsonValue;
-
 mod serde;
 
 pub mod directory;
 pub mod discovery;
 pub mod membership;
+pub mod pdu;
 pub mod query;
 pub mod transactions;
-
-/// A 'persistent data unit' (event) for room versions 3 and beyond.
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct RoomV3Pdu {
-    /// The room this event belongs to.
-    pub room_id: RoomId,
-    /// The user id of the user who sent this event.
-    pub sender: UserId,
-    /// The `server_name` of the homeserver that created this event.
-    pub origin: String,
-    /// Timestamp (milliseconds since the UNIX epoch) on originating homeserver
-    /// of when this event was created.
-    #[serde(with = "ruma_serde::time::ms_since_unix_epoch")]
-    pub origin_server_ts: SystemTime,
-
-    // TODO: Replace with event content collection from ruma-events once that exists
-    /// The event's type.
-    #[serde(rename = "type")]
-    pub kind: EventType,
-    /// The event's content.
-    pub content: JsonValue,
-
-    /// A key that determines which piece of room state the event represents.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub state_key: Option<String>,
-    /// Event IDs for the most recent events in the room that the homeserver was
-    /// aware of when it created this event.
-    pub prev_events: Vec<EventId>,
-    /// The maximum depth of the `prev_events`, plus one.
-    pub depth: UInt,
-    /// Event IDs for the authorization events that would allow this event to be
-    /// in the room.
-    pub auth_events: Vec<EventId>,
-    /// For redaction events, the ID of the event being redacted.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub redacts: Option<EventId>,
-    /// Additional data added by the origin server but not covered by the
-    /// signatures.
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub unsigned: BTreeMap<String, JsonValue>,
-    /// Content hashes of the PDU.
-    pub hashes: EventHash,
-    /// Signatures for the PDU.
-    pub signatures: BTreeMap<String, BTreeMap<String, String>>,
-}
-
-/// Content hashes of a PDU.
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct EventHash {
-    /// The SHA-256 hash.
-    pub sha256: String,
-}

--- a/src/membership/create_join_event/mod.rs
+++ b/src/membership/create_join_event/mod.rs
@@ -5,7 +5,7 @@ pub mod v1;
 use ruma_events::EventJson;
 use serde::{Deserialize, Serialize};
 
-use crate::RoomV3Pdu;
+use crate::pdu::Pdu;
 
 /// Full state of the room.
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -14,7 +14,7 @@ pub struct RoomState {
     pub origin: String,
     /// The full set of authorization events that make up the state of the room,
     /// and their authorization events, recursively.
-    pub auth_chain: Vec<EventJson<RoomV3Pdu>>,
+    pub auth_chain: Vec<EventJson<Pdu>>,
     /// The room state.
-    pub state: Vec<EventJson<RoomV3Pdu>>,
+    pub state: Vec<EventJson<Pdu>>,
 }

--- a/src/membership/create_join_event/v1.rs
+++ b/src/membership/create_join_event/v1.rs
@@ -1,15 +1,10 @@
 //! [PUT /_matrix/federation/v1/send_join/{roomId}/{eventId}](https://matrix.org/docs/spec/server_server/r0.1.3#put-matrix-federation-v1-send-join-roomid-eventid)
 
-use std::{collections::BTreeMap, time::SystemTime};
-
-use js_int::UInt;
 use ruma_api::ruma_api;
-use ruma_events::EventType;
-use ruma_identifiers::{EventId, RoomId, UserId};
-use serde_json::Value as JsonValue;
+use ruma_identifiers::{EventId, RoomId};
 
 use super::RoomState;
-use crate::{EventHash, RoomV3Pdu};
+use crate::pdu::PduStub;
 
 ruma_api! {
     metadata {
@@ -29,44 +24,9 @@ ruma_api! {
         #[ruma_api(path)]
         pub event_id: EventId,
 
-        /// The user id of the user who sent this event.
-        pub sender: UserId,
-        /// The `server_name` of the homeserver that created this event.
-        pub origin: String,
-        /// Timestamp (milliseconds since the UNIX epoch) on originating homeserver
-        /// of when this event was created.
-        #[serde(with = "ruma_serde::time::ms_since_unix_epoch")]
-        pub origin_server_ts: SystemTime,
-
-        // TODO: Replace with event content collection from ruma-events once that exists
-        /// The event's type.
-        #[serde(rename = "type")]
-        pub kind: EventType,
-        /// The event's content.
-        pub content: JsonValue,
-
-        /// A key that determines which piece of room state the event represents.
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pub state_key: Option<String>,
-        /// Event IDs for the most recent events in the room that the homeserver was
-        /// aware of when it created this event.
-        pub prev_events: Vec<EventId>,
-        /// The maximum depth of the `prev_events`, plus one.
-        pub depth: UInt,
-        /// Event IDs for the authorization events that would allow this event to be
-        /// in the room.
-        pub auth_events: Vec<EventId>,
-        /// For redaction events, the ID of the event being redacted.
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pub redacts: Option<EventId>,
-        /// Additional data added by the origin server but not covered by the
-        /// signatures.
-        #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-        pub unsigned: BTreeMap<String, JsonValue>,
-        /// Content hashes of the PDU.
-        pub hashes: EventHash,
-        /// Signatures for the PDU.
-        pub signatures: BTreeMap<String, BTreeMap<String, String>>,
+        /// PDU type without event and room IDs.
+        #[serde(flatten)]
+        pub pdu_stub: PduStub,
     }
 
     response {
@@ -77,28 +37,65 @@ ruma_api! {
     }
 }
 
-impl Request {
-    /// Helper method to get event ID and PDU (with room ID) from the request
-    /// parameters.
-    pub fn into_id_and_v3_pdu(self) -> (EventId, RoomV3Pdu) {
-        (
-            self.event_id,
-            RoomV3Pdu {
-                room_id: self.room_id,
-                sender: self.sender,
-                origin: self.origin,
-                origin_server_ts: self.origin_server_ts,
-                kind: self.kind,
-                content: self.content,
-                state_key: self.state_key,
-                prev_events: self.prev_events,
-                depth: self.depth,
-                auth_events: self.auth_events,
-                redacts: self.redacts,
-                unsigned: self.unsigned,
-                hashes: self.hashes,
-                signatures: self.signatures,
-            },
-        )
+/*
+#[cfg(test)]
+mod tests {
+
+    use std::{collections::BTreeMap, convert::TryFrom, time::SystemTime};
+
+    use ruma_events::{room::create::CreateEventContent, EventJson, EventType};
+    use ruma_identifiers::{EventId, RoomId, UserId};
+    use serde_json::json;
+
+    use super::Request;
+    use crate::pdu::EventHash;
+    use crate::pdu::{PduStub, RoomV1PduStub};
+
+    #[test]
+    fn test_serialize_request() {
+        let mut signatures = BTreeMap::new();
+        let mut inner_signature = BTreeMap::new();
+        inner_signature.insert(
+            "ed25519:key_version".to_string(),
+            "86BytesOfSignatureOfTheRedactedEvent".to_string(),
+        );
+        signatures.insert("example.com".to_string(), inner_signature);
+        let mut unsigned = BTreeMap::new();
+        unsigned.insert("somekey".to_string(), json!({"a": 456}));
+        let request = Request {
+            room_id: RoomId::try_from("someroomid").unwrap(),
+            event_id: EventId::try_from("12345").unwrap(),
+            pdu_stub: PduStub::RoomV1PduStub(RoomV1PduStub {
+                sender: UserId::try_from("@sender:example.com").unwrap(),
+                origin: "matrix.org".to_string(),
+                origin_server_ts: SystemTime::now(),
+                kind: EventType::RoomPowerLevels,
+                content: json!({"testing": 123}),
+                state_key: Some("state".to_string()),
+                prev_events: vec![(
+                    EventId::try_from("!previousevent:matrix.org").unwrap(),
+                    EventHash {
+                        sha256: "123567".to_string(),
+                    },
+                )],
+                depth: 2_u32.into(),
+                auth_events: vec![(
+                    EventId::try_from("!someauthevent:matrix.org").unwrap(),
+                    EventHash {
+                        sha256: "21389CFEDABC".to_string(),
+                    },
+                )],
+                redacts: Some(EventId::try_from("9654").unwrap()),
+                unsigned,
+                hashes: EventHash {
+                    sha256: "1233543bABACDEF".to_string(),
+                },
+                signatures,
+            }),
+        };
+
+        TryFrom::<http::Request<Vec<u8>>>(request);
+        println!("{}", serde_json::to_string_pretty(&request).unwrap());
     }
 }
+*/

--- a/src/membership/create_join_event_template/v1.rs
+++ b/src/membership/create_join_event_template/v1.rs
@@ -5,7 +5,7 @@ use ruma_api::ruma_api;
 use ruma_events::EventJson;
 use ruma_identifiers::{RoomId, UserId};
 
-use crate::RoomV3Pdu;
+use crate::pdu::Pdu;
 
 ruma_api! {
     metadata {
@@ -34,6 +34,6 @@ ruma_api! {
         /// The version of the room where the server is trying to join.
         pub room_version: Option<UInt>,
         /// An unsigned template event.
-        pub event: EventJson<RoomV3Pdu>,
+        pub event: EventJson<Pdu>,
     }
 }

--- a/src/pdu.rs
+++ b/src/pdu.rs
@@ -1,0 +1,461 @@
+//! Types for persistent data unit schemas
+
+use std::{collections::BTreeMap, time::SystemTime};
+
+use ::serde::{Deserialize, Serialize};
+use js_int::UInt;
+use ruma_events::EventType;
+use ruma_identifiers::{EventId, RoomId, UserId};
+use serde_json::Value as JsonValue;
+
+/// Enum for PDU schemas
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum Pdu {
+    /// PDU for room versions 1 and 2.
+    RoomV1Pdu(RoomV1Pdu),
+    /// PDU for room versions 3 and above.
+    RoomV3Pdu(RoomV3Pdu),
+}
+
+/// A 'persistent data unit' (event) for room versions 1 and 2.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct RoomV1Pdu {
+    /// Event ID for the PDU.
+    pub event_id: EventId,
+
+    /// The room this event belongs to.
+    pub room_id: RoomId,
+
+    /// The user id of the user who sent this event.
+    pub sender: UserId,
+
+    /// The `server_name` of the homeserver that created this event.
+    pub origin: String,
+
+    /// Timestamp (milliseconds since the UNIX epoch) on originating homeserver
+    /// of when this event was created.
+    #[serde(with = "ruma_serde::time::ms_since_unix_epoch")]
+    pub origin_server_ts: SystemTime,
+
+    // TODO: Replace with event content collection from ruma-events once that exists
+    /// The event's type.
+    #[serde(rename = "type")]
+    pub kind: EventType,
+
+    /// The event's content.
+    pub content: JsonValue,
+
+    /// A key that determines which piece of room state the event represents.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state_key: Option<String>,
+
+    /// Event IDs for the most recent events in the room that the homeserver was
+    /// aware of when it created this event.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub prev_events: Vec<(EventId, EventHash)>,
+
+    /// The maximum depth of the `prev_events`, plus one.
+    pub depth: UInt,
+
+    /// Event IDs for the authorization events that would allow this event to be
+    /// in the room.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub auth_events: Vec<(EventId, EventHash)>,
+
+    /// For redaction events, the ID of the event being redacted.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub redacts: Option<EventId>,
+
+    /// Additional data added by the origin server but not covered by the
+    /// signatures.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub unsigned: BTreeMap<String, JsonValue>,
+
+    /// Content hashes of the PDU.
+    pub hashes: EventHash,
+
+    /// Signatures for the PDU.
+    pub signatures: BTreeMap<String, BTreeMap<String, String>>,
+}
+/// A 'persistent data unit' (event) for room versions 3 and beyond.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct RoomV3Pdu {
+    /// The room this event belongs to.
+    pub room_id: RoomId,
+
+    /// The user id of the user who sent this event.
+    pub sender: UserId,
+
+    /// The `server_name` of the homeserver that created this event.
+    pub origin: String,
+
+    /// Timestamp (milliseconds since the UNIX epoch) on originating homeserver
+    /// of when this event was created.
+    #[serde(with = "ruma_serde::time::ms_since_unix_epoch")]
+    pub origin_server_ts: SystemTime,
+
+    // TODO: Replace with event content collection from ruma-events once that exists
+    /// The event's type.
+    #[serde(rename = "type")]
+    pub kind: EventType,
+
+    /// The event's content.
+    pub content: JsonValue,
+
+    /// A key that determines which piece of room state the event represents.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state_key: Option<String>,
+
+    /// Event IDs for the most recent events in the room that the homeserver was
+    /// aware of when it created this event.
+    pub prev_events: Vec<EventId>,
+
+    /// The maximum depth of the `prev_events`, plus one.
+    pub depth: UInt,
+
+    /// Event IDs for the authorization events that would allow this event to be
+    /// in the room.
+    pub auth_events: Vec<EventId>,
+
+    /// For redaction events, the ID of the event being redacted.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub redacts: Option<EventId>,
+
+    /// Additional data added by the origin server but not covered by the
+    /// signatures.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub unsigned: BTreeMap<String, JsonValue>,
+
+    /// Content hashes of the PDU.
+    pub hashes: EventHash,
+
+    /// Signatures for the PDU.
+    pub signatures: BTreeMap<String, BTreeMap<String, String>>,
+}
+
+/// Content hashes of a PDU.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct EventHash {
+    /// The SHA-256 hash.
+    pub sha256: String,
+}
+
+/// PDU type without event and room IDs.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum PduStub {
+    /// Stub for PDUs of room version 1 and 2.
+    RoomV1PduStub(RoomV1PduStub),
+
+    /// Stub for PDUs of room versions 3 and above.
+    RoomV3PduStub(RoomV3PduStub),
+}
+
+impl PduStub {
+    /// Helper method to get event ID and PDU (with room ID) from the request
+    /// parameters.
+    pub fn into_pdu(self, room_id: RoomId, event_id: EventId) -> Pdu {
+        match self {
+            PduStub::RoomV1PduStub(v1_stub) => Pdu::RoomV1Pdu(RoomV1Pdu {
+                event_id,
+                room_id,
+                sender: v1_stub.sender,
+                origin: v1_stub.origin,
+                origin_server_ts: v1_stub.origin_server_ts,
+                kind: v1_stub.kind,
+                content: v1_stub.content,
+                state_key: v1_stub.state_key,
+                prev_events: v1_stub.prev_events,
+                depth: v1_stub.depth,
+                auth_events: v1_stub.auth_events,
+                redacts: v1_stub.redacts,
+                unsigned: v1_stub.unsigned,
+                hashes: v1_stub.hashes,
+                signatures: v1_stub.signatures,
+            }),
+            PduStub::RoomV3PduStub(v3_stub) => Pdu::RoomV3Pdu(RoomV3Pdu {
+                room_id,
+                sender: v3_stub.sender,
+                origin: v3_stub.origin,
+                origin_server_ts: v3_stub.origin_server_ts,
+                kind: v3_stub.kind,
+                content: v3_stub.content,
+                state_key: v3_stub.state_key,
+                prev_events: v3_stub.prev_events,
+                depth: v3_stub.depth,
+                auth_events: v3_stub.auth_events,
+                redacts: v3_stub.redacts,
+                unsigned: v3_stub.unsigned,
+                hashes: v3_stub.hashes,
+                signatures: v3_stub.signatures,
+            }),
+        }
+    }
+}
+
+/// Stub for PDUs of room version 1 and 2.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct RoomV1PduStub {
+    /// The user id of the user who sent this event.
+    pub sender: UserId,
+
+    /// The `server_name` of the homeserver that created this event.
+    pub origin: String,
+
+    /// Timestamp (milliseconds since the UNIX epoch) on originating homeserver
+    /// of when this event was created.
+    #[serde(with = "ruma_serde::time::ms_since_unix_epoch")]
+    pub origin_server_ts: SystemTime,
+
+    // TODO: Replace with event content collection from ruma-events once that exists
+    /// The event's type.
+    #[serde(rename = "type")]
+    pub kind: EventType,
+
+    /// The event's content.
+    pub content: JsonValue,
+
+    /// A key that determines which piece of room state the event represents.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state_key: Option<String>,
+
+    /// Event IDs for the most recent events in the room that the homeserver was
+    /// aware of when it created this event.
+    pub prev_events: Vec<(EventId, EventHash)>,
+
+    /// The maximum depth of the `prev_events`, plus one.
+    pub depth: UInt,
+
+    /// Event IDs for the authorization events that would allow this event to be
+    /// in the room.
+    pub auth_events: Vec<(EventId, EventHash)>,
+
+    /// For redaction events, the ID of the event being redacted.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub redacts: Option<EventId>,
+
+    /// Additional data added by the origin server but not covered by the
+    /// signatures.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub unsigned: BTreeMap<String, JsonValue>,
+
+    /// Content hashes of the PDU.
+    pub hashes: EventHash,
+
+    /// Signatures for the PDU.
+    pub signatures: BTreeMap<String, BTreeMap<String, String>>,
+}
+
+/// Stub for PDUs of room versions 3 and above.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct RoomV3PduStub {
+    /// The user id of the user who sent this event.
+    pub sender: UserId,
+
+    /// The `server_name` of the homeserver that created this event.
+    pub origin: String,
+
+    /// Timestamp (milliseconds since the UNIX epoch) on originating homeserver
+    /// of when this event was created.
+    #[serde(with = "ruma_serde::time::ms_since_unix_epoch")]
+    pub origin_server_ts: SystemTime,
+
+    // TODO: Replace with event content collection from ruma-events once that exists
+    /// The event's type.
+    #[serde(rename = "type")]
+    pub kind: EventType,
+
+    /// The event's content.
+    pub content: JsonValue,
+
+    /// A key that determines which piece of room state the event represents.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state_key: Option<String>,
+
+    /// Event IDs for the most recent events in the room that the homeserver was
+    /// aware of when it created this event.
+    pub prev_events: Vec<EventId>,
+
+    /// The maximum depth of the `prev_events`, plus one.
+    pub depth: UInt,
+
+    /// Event IDs for the authorization events that would allow this event to be
+    /// in the room.
+    pub auth_events: Vec<EventId>,
+
+    /// For redaction events, the ID of the event being redacted.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub redacts: Option<EventId>,
+
+    /// Additional data added by the origin server but not covered by the
+    /// signatures.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub unsigned: BTreeMap<String, JsonValue>,
+
+    /// Content hashes of the PDU.
+    pub hashes: EventHash,
+
+    /// Signatures for the PDU.
+    pub signatures: BTreeMap<String, BTreeMap<String, String>>,
+}
+
+#[cfg(test)]
+mod tests {
+
+    use std::{convert::TryFrom, time::SystemTime};
+
+    use serde_json::{from_value as from_json_value, json};
+
+    use super::*;
+    #[test]
+    fn test_serialize_pdu_stub() {
+
+        let mut signatures = BTreeMap::new();
+        let mut inner_signature = BTreeMap::new();
+        inner_signature.insert(
+            "ed25519:key_version".to_string(),
+            "86BytesOfSignatureOfTheRedactedEvent".to_string(),
+        );
+        signatures.insert("example.com".to_string(), inner_signature);
+
+        let mut unsigned = BTreeMap::new();
+        unsigned.insert("somekey".to_string(), json!({"a": 456}));
+
+        let v1_stub = RoomV1PduStub {
+            sender: UserId::try_from("@sender:example.com").unwrap(),
+            origin: "matrix.org".to_string(),
+            origin_server_ts: SystemTime::now(),
+            kind: EventType::RoomPowerLevels,
+            content: json!({"testing": 123}),
+            state_key: Some("state".to_string()),
+            prev_events: vec![(
+                EventId::try_from("$previousevent:matrix.org").unwrap(),
+                EventHash {
+                    sha256: "123567".to_string(),
+                },
+            )],
+            depth: 2_u32.into(),
+            auth_events: vec![(
+                EventId::try_from("$someauthevent:matrix.org").unwrap(),
+                EventHash {
+                    sha256: "21389CFEDABC".to_string(),
+                },
+            )],
+            redacts: Some(EventId::try_from("$9654:matrix.org").unwrap()),
+            unsigned,
+            hashes: EventHash {
+                sha256: "1233543bABACDEF".to_string(),
+            },
+            signatures,
+        };
+        let pdu_stub = PduStub::RoomV1PduStub(v1_stub);
+        // TODO: Test for a real value
+        assert!(true);
+    }
+
+    #[test]
+    fn test_deserialize_v1_stub() {
+        let json = json!({
+            "auth_events": [
+                [
+                    "$abc123:matrix.org",
+                    {
+                        "sha256": "Base64EncodedSha256HashesShouldBe43BytesLong"
+                    }
+                ]
+            ],
+            "content": {
+                "key": "value"
+            },
+            "depth": 12,
+            "event_id": "$a4ecee13e2accdadf56c1025:example.com",
+            "hashes": {
+                "sha256": "ThisHashCoversAllFieldsInCaseThisIsRedacted"
+            },
+            "origin": "matrix.org",
+            "origin_server_ts": 1234567890,
+            "prev_events": [
+                [
+                    "$abc123:matrix.org",
+                    {
+                        "sha256": "Base64EncodedSha256HashesShouldBe43BytesLong"
+                    }
+                ]
+            ],
+            "redacts": "$def456:matrix.org",
+            "room_id": "!abc123:matrix.org",
+            "sender": "@someone:matrix.org",
+            "signatures": {
+                "example.com": {
+                    "ed25519:key_version:": "86BytesOfSignatureOfTheRedactedEvent"
+                }
+            },
+            "state_key": "my_key",
+            "type": "m.room.message",
+            "unsigned": {
+                "key": "value"
+            }
+        });
+        let parsed = from_json_value::<PduStub>(json).unwrap();
+
+        match parsed {
+            PduStub::RoomV1PduStub(v1_stub) => {
+                assert_eq!(
+                    v1_stub.auth_events.first().unwrap().0,
+                    EventId::try_from("$abc123:matrix.org").unwrap()
+                );
+                assert_eq!(
+                    v1_stub.auth_events.first().unwrap().1.sha256,
+                    "Base64EncodedSha256HashesShouldBe43BytesLong"
+                );
+            },
+            PduStub::RoomV3PduStub(_) => panic!("Matched V3 stub"),
+        }
+    }
+    
+    #[test]
+    fn test_deserialize_v3_stub() {
+        let json = json!({
+            "auth_events": [
+                    "$abc123:matrix.org"
+            ],
+            "content": {
+                "key": "value"
+            },
+            "depth": 12,
+            "event_id": "$a4ecee13e2accdadf56c1025:example.com",
+            "hashes": {
+                "sha256": "ThisHashCoversAllFieldsInCaseThisIsRedacted"
+            },
+            "origin": "matrix.org",
+            "origin_server_ts": 1234567890,
+            "prev_events": [
+                    "$abc123:matrix.org"
+            ],
+            "redacts": "$def456:matrix.org",
+            "room_id": "!abc123:matrix.org",
+            "sender": "@someone:matrix.org",
+            "signatures": {
+                "example.com": {
+                    "ed25519:key_version:": "86BytesOfSignatureOfTheRedactedEvent"
+                }
+            },
+            "state_key": "my_key",
+            "type": "m.room.message",
+            "unsigned": {
+                "key": "value"
+            }
+        });
+        let parsed = from_json_value::<PduStub>(json).unwrap();
+
+        match parsed {
+            PduStub::RoomV1PduStub(_) => panic!("Matched V1 stub"),
+            PduStub::RoomV3PduStub(v3_stub) => {
+                assert_eq!(
+                    v3_stub.auth_events.first().unwrap(),
+                    &EventId::try_from("$abc123:matrix.org").unwrap()
+                );
+            },
+        }
+    }
+}

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -1,0 +1,3 @@
+//! Endpoints for exchanging transaction messages between homeservers.
+
+pub mod send_transaction_message;

--- a/src/transactions/send_transaction_message/mod.rs
+++ b/src/transactions/send_transaction_message/mod.rs
@@ -1,0 +1,3 @@
+//! Endpoint to send live activity messages to another server.
+
+pub mod v1;

--- a/src/transactions/send_transaction_message/v1.rs
+++ b/src/transactions/send_transaction_message/v1.rs
@@ -1,0 +1,63 @@
+//! [PUT /_matrix/federation/v1/send/{txnId}](https://matrix.org/docs/spec/server_server/r0.1.3#put-matrix-federation-v1-send-txnid)
+
+use std::{collections::BTreeMap, time::SystemTime};
+
+use ruma_api::ruma_api;
+use ruma_identifiers::EventId;
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+
+use crate::RoomV3Pdu;
+
+ruma_api! {
+    metadata {
+        description: "Send transaction messages to another server",
+        name: "send_transaction_message",
+        method: PUT,
+        path: "/_matrix/federation/v1/send/:transaction_id",
+        rate_limited: false,
+        requires_authentication: true,
+    }
+
+    request {
+        /// A transaction ID unique between sending and receiving homeservers.
+        #[ruma_api(path)]
+        pub transaction_id: String,
+        /// The server_name of the homeserver sending this transaction.
+        pub origin: String,
+        /// POSIX timestamp in milliseconds on originating homeserver when this transaction started.
+        #[serde(with = "ruma_serde::time::ms_since_unix_epoch")]
+        pub origin_server_ts: SystemTime,
+        /// List of persistent updates to rooms.
+        ///
+        /// Must not be more than 50 items.
+        pub pdus: Vec<RoomV3Pdu>,
+        /// List of ephemeral messages.
+        ///
+        /// Must not be more than 100 items.
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        pub edus: Vec<Edu>,
+    }
+
+    response {
+        /// Map of event IDs and response for each PDU given in the request.
+        pub pdus: BTreeMap<EventId, PduProcessResponse>,
+    }
+}
+
+/// Type for passing ephemeral data to homeservers.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Edu {
+    /// Type of the ephemeral message.
+    pub edu_type: String,
+    /// Content of ephemeral message
+    pub content: JsonValue,
+}
+
+/// Error messages (if any) for a given PDU proccessing result.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct PduProcessResponse {
+    /// PDU processing error message.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}

--- a/src/transactions/send_transaction_message/v1.rs
+++ b/src/transactions/send_transaction_message/v1.rs
@@ -7,7 +7,7 @@ use ruma_identifiers::EventId;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
-use crate::RoomV3Pdu;
+use crate::pdu::Pdu;
 
 ruma_api! {
     metadata {
@@ -31,7 +31,7 @@ ruma_api! {
         /// List of persistent updates to rooms.
         ///
         /// Must not be more than 50 items.
-        pub pdus: Vec<RoomV3Pdu>,
+        pub pdus: Vec<Pdu>,
         /// List of ephemeral messages.
         ///
         /// Must not be more than 100 items.


### PR DESCRIPTION
I found that this endpoint has the same issue as the create_join_event endpoint with the `[200, {}]` response. I want to research whether making the current module in `serde::room_state` generic for all of these endpoints, since it seems that there half a dozen or so of these endpoints.